### PR TITLE
vidpf: Add PLASMA-style path verifiability

### DIFF
--- a/poc/vidpf.py
+++ b/poc/vidpf.py
@@ -98,16 +98,16 @@ class Vidpf:
     @classmethod
     def eval(cls, agg_id, correction_words, init_seed, level, prefixes, cs_proofs, pi_proof, binder):
         if agg_id >= cls.SHARES:
-            raise ERR_INPUT  # invalid aggregator ID
+            raise ValueError("invalid aggregator ID")
         if level >= cls.BITS:
-            raise ERR_INPUT  # level too deep
+            raise ValueError("level too deep")
         if len(set(prefixes)) != len(prefixes):
-            raise ERR_INPUT  # candidate prefixes are non-unique
+            raise ValueError("candidate prefixes are non-unique")
 
         out_share = []
         for prefix in prefixes:
             if prefix >= 2 ** (level+1):
-                raise ERR_INPUT  # prefix too long
+                raise ValueError("prefix too long")
 
             # The Aggregator's output share is the value of a node of
             # the IDPF tree at the given `level`. The node's value is
@@ -135,7 +135,6 @@ class Vidpf:
                 # wasteful. Implementations can eliminate this added
                 # complexity by caching nodes (i.e., `(seed, ctrl)`
                 # pairs) output by previous calls to `eval_next()`.
-
                 (seed, ctrl, y, pi_proof) = cls.eval_next(
                     seed,
                     ctrl,


### PR DESCRIPTION
As discussed here in https://github.com/jimouris/draft-mouris-cfrg-mastic/pull/20#discussion_r1362349956, for each node in the prefix tree we wish to check that the children sum up to the same value.

Previously we had discussed handling path verifiability at a higher level, in Mastic itself. Indeed, it's possible to use the current VIDPF in a black-box manner and perform the same calculation. However, the resulting algorithm would have asymptotic runtime that is far worse than optimal. Instead, I followed @hannahdaviscrypto's suggestion to modify VIDPF so that it does the path verification itself. The resulting algorithm is as fast as we can hope for, at least asymptotically. (Concretely there is more room for optimization.)

When specifying a complex algorithm like this, it's often useful to write down the asymptotically-optimal version. I think it makes sense to do the same thing here.

This PR also stacks some minor changes to `vidpf` that are technically separate. It may help to review commit-by-commit.