### PR TITLE
Clarify and speed up mastic implementation

### DIFF
--- a/poc/vdaf_mastic.py
+++ b/poc/vdaf_mastic.py
@@ -96,6 +96,11 @@ class Mastic(Vdaf):
             # One solution is to make the first level a parameter of the VDAF.
             # This is probably a good idea anyway, since it's a trade-off the
             # Aggregators will probably want to agree on anyway.
+            #
+            # Another solution is to change the formatting of agg_param to
+            # support tuples of (level, prefixes) pairs. This would allow the
+            # VDAF to validate levels '0' and '7' in a single round trip,
+            # thus supporting faststart without changing the validity condition.
             return (
                 (len(previous_agg_params) == 0 and level == 0) or \
                 previous_agg_params[0][0] == 0
@@ -158,6 +163,8 @@ class Mastic(Vdaf):
                                                         cls.ROOT_PROOF,
                                                         nonce)
             meas_share = vec_add(out_share[0], out_share[1])
+            # As a consequence of VIDPF path verifiability,
+            # meas_share contains the value of the root node in the VIDPF tree
 
             query_rand = cls.Xof.expand_into_vec(
                 cls.Flp.Field,
@@ -188,7 +195,8 @@ class Mastic(Vdaf):
         (level_proof_0, verifier_share_0) = prep_shares[0]
         (level_proof_1, verifier_share_1) = prep_shares[1]
         if level_proof_0 != level_proof_1:
-            raise Exception('output vector is not one-hot')
+            raise Exception('output vector is not one-hot or VIDPF output is \
+                            inconsistent between levels')
 
         # Finish verifying the FLP, if applicable.
         if cls.do_range_check(agg_param):

--- a/poc/vidpf.py
+++ b/poc/vidpf.py
@@ -113,8 +113,8 @@ class Vidpf:
             if prefix >= 2 ** (level+1):
                 raise ValueError("prefix too long")
 
-            # The Aggregator's output share is the value of a node of
-            # the IDPF tree at the given `level`. The node's value is
+            # The Aggregator's output share is the value of one or more nodes of
+            # the IDPF tree at the given `level`. These nodes' values are
             # computed by traversing the path defined by the candidate
             # `prefix`. Each node in the tree is represented by a seed
             # (`seed`) and a set of control bits (`ctrl`).
@@ -142,7 +142,10 @@ class Vidpf:
         # Compute the path verifier.
         sha3 = hashlib.sha3_256()
         for prefix in prefixes:
-            for current_level in range(level):
+            start = 0
+            if cls.INCREMENTAL_MODE:
+                start = level-1
+            for current_level in range(start, level):
                 node = prefix >> (level - current_level)
                 y =  prefix_tree_share[(node,        current_level)  ][2]
                 y0 = prefix_tree_share[(node<<1,     current_level+1)][2]


### PR DESCRIPTION
Clarifying certain comments and error messages in the Mastic implementation. The only significant change is to VIDPF.eval, which now uses the INCREMENTAL_MODE flag to determine whether to establish path-verifiability for the whole tree or a single layer. This should eliminate redundant hashing in incremental mode and slightly improve efficiency.