### PR TITLE
Automatic update of .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Automatically generated CODEOWNERS
 # Regenerate with `make update-codeowners`
-draft-mouris-cfrg-mastic.md hannahedavis@protonmail.com jimouris@udel.edu pratik93@bu.edu tsoutsos@udel.edu
+draft-mouris-cfrg-mastic.md hannah.e.davis@seagate.com jimouris@udel.edu chrispatton+ietf@gmail.com pratik93@bu.edu tsoutsos@udel.edu


### PR DESCRIPTION
Automated via `make update-codeowners`