### PR TITLE
vidpf: Use the `Xof` API from the base draft for hashing

### DIFF
--- a/poc/vidpf.py
+++ b/poc/vidpf.py
@@ -255,7 +255,6 @@ class Vidpf:
         xof = XofShake128(seed, b'vidpf cs proof', binder)
         return xof.next(PROOF_SIZE)
 
-
     @classmethod
     def with_params(cls, f, bits, value_len):
         class VdipfWithField(cls):


### PR DESCRIPTION
Closes #17.

Replace SHA-3 with `XofShake128` (SHAKE128). This has two benefits:

1. It simplifies domain separation, which will be useful if we end up needing to model instances of this object as random oracles in security proofs.

2. It allows us to easily swap `XofShake128` with `XofTurboShake128` (TurboSHAKE128) as required in the next draft (draft-irtf-cfrg-vdaf-08).

We also replace update the base "cs proof" by using the SHA256 hash of a fixed string instead of SHA3. This is because SHA256 is more likely to be implemented in common cryptographic libraries.