### PR TITLE
Upgrade reference to base draft

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,8 @@ jobs:
     - name: Install Sage
       run: |
         sudo apt-get update
-        sudo apt-get install -y sagemath python3-pycryptodome python3-cffi
+        sudo apt-get install -y sagemath python3-cffi
+        sage -pip install pycryptodomex
 
     - name: Run tests
       working-directory: poc

--- a/poc/vdaf_mastic.py
+++ b/poc/vdaf_mastic.py
@@ -10,7 +10,7 @@ from typing import Optional, Union
 from common import Unsigned, byte, concat, front, vec_add, vec_sub, zeros
 from flp_generic import FlpGeneric
 from vdaf import Vdaf, test_vdaf
-from xof import XofShake128
+from xof import XofTurboShake128
 
 from vidpf import Vidpf
 
@@ -38,7 +38,7 @@ class Mastic(Vdaf):
     Field = None  # Set by `with_params()`
     Vidpf = None  # Set by `with_params()`
     Flp = None  # Set by `with_params()`
-    Xof = XofShake128
+    Xof = XofTurboShake128
 
     # Parameters required by `Vdaf`.
     ID: Unsigned = 0xFFFFFFFF
@@ -396,10 +396,10 @@ class Mastic(Vdaf):
             RAND_SIZE = Vidpf.RAND_SIZE
             if Flp.JOINT_RAND_LEN > 0:
                 # flp_prove_rand_seed, flp_leader_seed, flp_helper_seed
-                RAND_SIZE += 3 * XofShake128.SEED_SIZE
+                RAND_SIZE += 3 * XofTurboShake128.SEED_SIZE
             else:
                 # flp_prove_rand_seed, flp_helper_seed
-                RAND_SIZE += 2 * XofShake128.SEED_SIZE
+                RAND_SIZE += 2 * XofTurboShake128.SEED_SIZE
 
             # `alpha` and the un-encoded `beta`.
             Measurement = tuple[Unsigned,

--- a/poc/vidpf.py
+++ b/poc/vidpf.py
@@ -10,7 +10,7 @@ import itertools
 from common import (format_dst, gen_rand, to_le_bytes, vec_add, vec_neg,
                     vec_sub, xor, zeros)
 from field import Field2, Field128
-from xof import XofFixedKeyAes128, XofShake128
+from xof import XofFixedKeyAes128, XofTurboShake128
 
 ROOT_PI_PROOF = hashlib.sha256(b"vidpf root pi proof").digest()
 
@@ -253,7 +253,7 @@ class Vidpf:
         binder = to_le_bytes(cls.BITS, 2) \
             + to_le_bytes(node, (cls.BITS + 7) // 8) \
             + to_le_bytes(level, 2)
-        xof = XofShake128(seed, b'vidpf cs proof', binder)
+        xof = XofTurboShake128(seed, b'vidpf cs proof', binder)
         return xof.next(PROOF_SIZE)
 
     @classmethod
@@ -293,8 +293,8 @@ def correct(k_0, k_1, ctrl):
 
 
 def pi_proof_adjustment(h2):
-    xof = XofShake128(
-        zeros(XofShake128.SEED_SIZE),
+    xof = XofTurboShake128(
+        zeros(XofTurboShake128.SEED_SIZE),
         b'vidpf proof adjustment',
         h2,
     )
@@ -302,8 +302,8 @@ def pi_proof_adjustment(h2):
 
 
 def eval_proof(pi_proof, counter, path):
-    xof = XofShake128(
-        zeros(XofShake128.SEED_SIZE),
+    xof = XofTurboShake128(
+        zeros(XofTurboShake128.SEED_SIZE),
         b'vidpf eval proof',
         pi_proof + counter + path,
     )


### PR DESCRIPTION
In draft-08, SHAKE was replaced with TurboSHAKE, so upgrade the dependency accordingly.

The latest version of the main branch has been checked out rather than the tagged version (draft-irtf-cfrg-vdaf-08). This is because the latest version resolves a technical issue regarding the implementation of TurboSHAKE. This was resolved by upgrading PyCryptodomex to the latest version:

$ sage -pip install --upgrade pycryptodomex

Version 3.20.0 is required.