### PR TITLE
Clean up TODOs

### DIFF
--- a/poc/tests/test_vidpf.py
+++ b/poc/tests/test_vidpf.py
@@ -4,7 +4,7 @@ from random import randrange
 from vdaf_poc.common import gen_rand, vec_add
 from vdaf_poc.field import Field128
 
-from vidpf import PROOF_INIT, PrefixTreeEntry, PrefixTreeIndex, Vidpf
+from vidpf import PATH_PROOF_INIT, PrefixTreeEntry, PrefixTreeIndex, Vidpf
 
 
 class Test(unittest.TestCase):
@@ -21,7 +21,7 @@ class Test(unittest.TestCase):
             PrefixTreeEntry.root(keys[0], False),
             PrefixTreeEntry.root(keys[1], True),
         ]
-        proof = [PROOF_INIT, PROOF_INIT]
+        proof = [PATH_PROOF_INIT, PATH_PROOF_INIT]
         for i in range(vidpf.BITS):
             idx = PrefixTreeIndex(alpha >> (vidpf.BITS - i - 1), i)
             (node[0], proof[0]) = vidpf.eval_next(
@@ -46,7 +46,7 @@ class Test(unittest.TestCase):
             PrefixTreeEntry.root(keys[0], False),
             PrefixTreeEntry.root(keys[1], True),
         ]
-        proof = [PROOF_INIT, PROOF_INIT]
+        proof = [PATH_PROOF_INIT, PATH_PROOF_INIT]
         for i in range(vidpf.BITS):
             # We want an off-path index. The sibling of the on-path prefix is
             # an off-path prefix.


### PR DESCRIPTION
Stacked on #69.
Partially addresses #34.

* Harmonize code used for domain separation. At the moment, we overload `Vdaf.domain_separation_tag()` to use our own `VERSION`, but we invoke `format_tag()`, which uses the version from the VDAF draft. Eventually we'll want to use our own version for both; for the moment, the minimally invasive change is to just use upstream.

* Add a NOTE about an apparent bug that's blocking us from making the XOF generic. This may be a `Vdaf` bug or a bug with `Generic` itself. While at it, deduplicate the code for deriving the prove randomness.

* Modify query randomness derivation by binding to the level. We only generate query randomness once, so this may not be strictly necessary. But this does provide domain separation whenever the aggregation starts at different levels.

    * Note: The TODO suggested binding to the aggregation parameter as
      well, but this doesn't seem necessary as the FLP can only be used
      once.

* Align correction word encoding with the IDPF specification in the base draft. Note that the considerations are a little different because we don't have a concept of "inner field" versus "leaf field", but consistency is nice.

* Rename the "counter" to the "counter check" and the "path" to the "payload check".

* Refer to the "VIDPF proof" from {{MST24}} as the "path proof". This is to distinguish it from the "evaluation proof", which includes the path proof and the counter and payload checks.