### PR TITLE
Clean up Mastic a bit

### DIFF
--- a/poc/mastic.py
+++ b/poc/mastic.py
@@ -41,11 +41,9 @@ MasticPrepState: TypeAlias = tuple[
 ]
 
 MasticPrepShare: TypeAlias = tuple[
-    bytes,  # VIDPF proof
-    Optional[tuple[
-        list[F],          # FLP verifier share
-        Optional[bytes],  # FLP joint randomness part
-    ]],
+    bytes,              # VIDPF proof
+    Optional[list[F]],  # FLP verifier share
+    Optional[bytes],    # FLP joint randomness part
 ]
 
 MasticPrepMessage: TypeAlias = Optional[bytes]  # FLP joint rand seed
@@ -83,13 +81,9 @@ class Mastic(
         self.field = valid.field
         self.flp = FlpBBCGGI19(valid)
         self.vidpf = Vidpf(valid.field, bits, valid.MEAS_LEN)
-        self.RAND_SIZE = self.vidpf.RAND_SIZE
-        if self.flp.JOINT_RAND_LEN > 0:
-            # flp_prove_rand_seed, flp_leader_seed, flp_helper_seed
-            self.RAND_SIZE += 3 * self.xof.SEED_SIZE
-        else:
-            # flp_prove_rand_seed, flp_helper_seed
-            self.RAND_SIZE += 2 * self.xof.SEED_SIZE
+        self.RAND_SIZE = self.vidpf.RAND_SIZE + 2 * self.xof.SEED_SIZE
+        if self.flp.JOINT_RAND_LEN > 0:  # FLP leader seed
+            self.RAND_SIZE += self.xof.SEED_SIZE
 
     def shard(self,
               measurement: tuple[int, Measurement],
@@ -98,8 +92,7 @@ class Mastic(
               ) -> tuple[MasticPublicShare, list[MasticInputShare]]:
         if self.flp.JOINT_RAND_LEN > 0:
             return self.shard_with_joint_rand(measurement, nonce, rand)
-        else:
-            return self.shard_without_joint_rand(measurement, nonce, rand)
+        return self.shard_without_joint_rand(measurement, nonce, rand)
 
     def shard_without_joint_rand(
             self,
@@ -107,29 +100,28 @@ class Mastic(
             nonce: bytes,
             rand: bytes,
     ) -> tuple[MasticPublicShare, list[MasticInputShare]]:
-        (vidpf_gen_rand, rand) = front(self.vidpf.RAND_SIZE, rand)
-        (flp_prove_rand_seed, rand) = front(self.xof.SEED_SIZE, rand)
-        (flp_helper_seed, rand) = front(self.xof.SEED_SIZE, rand)
+        (vidpf_rand, rand) = front(self.vidpf.RAND_SIZE, rand)
+        (prove_rand_seed, rand) = front(self.xof.SEED_SIZE, rand)
+        (helper_seed, rand) = front(self.xof.SEED_SIZE, rand)
+        assert len(rand) == 0  # REMOVE ME
 
         (alpha, meas) = measurement
         beta = self.flp.encode(meas)
 
         # Generate VIDPF keys.
-        (vidpf_public_share, vidpf_keys) = \
-            self.vidpf.gen(alpha, beta, nonce, vidpf_gen_rand)
+        (correction_words, keys) = \
+            self.vidpf.gen(alpha, beta, nonce, vidpf_rand)
 
-        # Generate FLP proof shares.
-        flp_prove_rand = self.prove_rand(flp_prove_rand_seed)
-        flp_proof = self.flp.prove(beta, flp_prove_rand, [])
-        flp_leader_proof_share = vec_sub(
-            flp_proof,
-            self.helper_proof_share(flp_helper_seed),
-        )
+        # Generate FLP and split it into shares.
+        prove_rand = self.prove_rand(prove_rand_seed)
+        proof = self.flp.prove(beta, prove_rand, [])
+        helper_proof_share = self.helper_proof_share(helper_seed)
+        leader_proof_share = vec_sub(proof, helper_proof_share)
 
-        public_share = (vidpf_public_share, None)
+        public_share = (correction_words, None)
         input_shares = [
-            (vidpf_keys[0], flp_leader_proof_share, None),
-            (vidpf_keys[1], None, flp_helper_seed),
+            (keys[0], leader_proof_share, None),
+            (keys[1], None, helper_seed),
         ]
         return (public_share, input_shares)
 
@@ -139,43 +131,39 @@ class Mastic(
             nonce: bytes,
             rand: bytes,
     ) -> tuple[MasticPublicShare, list[MasticInputShare]]:
-        flp_leader_proof_share: Optional[list[F]]
-        flp_public_share: Optional[list[bytes]]
-
-        (vidpf_gen_rand, rand) = front(self.vidpf.RAND_SIZE, rand)
-        (flp_prove_rand_seed, rand) = front(self.xof.SEED_SIZE, rand)
-        (flp_leader_seed, rand) = front(self.xof.SEED_SIZE, rand)
-        (flp_helper_seed, rand) = front(self.xof.SEED_SIZE, rand)
+        (vidpf_rand, rand) = front(self.vidpf.RAND_SIZE, rand)
+        (prove_rand_seed, rand) = front(self.xof.SEED_SIZE, rand)
+        (leader_seed, rand) = front(self.xof.SEED_SIZE, rand)
+        (helper_seed, rand) = front(self.xof.SEED_SIZE, rand)
+        assert len(rand) == 0  # REMOVE ME
 
         (alpha, meas) = measurement
         beta = self.flp.encode(meas)
 
         # Generate VIDPF keys.
-        (vidpf_public_share, vidpf_keys) = \
-            self.vidpf.gen(alpha, beta, nonce, vidpf_gen_rand)
+        (correction_words, keys) = \
+            self.vidpf.gen(alpha, beta, nonce, vidpf_rand)
 
         # Generate FLP joint randomness.
-        joint_rand_parts = []
-        joint_rand_parts.append(self.joint_rand_part(
-            0, flp_leader_seed, vidpf_keys[0], vidpf_public_share, nonce))
-        joint_rand_parts.append(self.joint_rand_part(
-            1, flp_helper_seed, vidpf_keys[1], vidpf_public_share, nonce))
+        joint_rand_parts = [
+            self.joint_rand_part(
+                0, leader_seed, keys[0], correction_words, nonce),
+            self.joint_rand_part(
+                1, helper_seed, keys[1], correction_words, nonce),
+        ]
         joint_rand = self.joint_rand(
             self.joint_rand_seed(joint_rand_parts))
-        flp_public_share = joint_rand_parts
 
-        # Generate FLP proof shares.
-        flp_prove_rand = self.prove_rand(flp_prove_rand_seed)
-        flp_proof = self.flp.prove(beta, flp_prove_rand, joint_rand)
-        flp_leader_proof_share = vec_sub(
-            flp_proof,
-            self.helper_proof_share(flp_helper_seed),
-        )
+        # Generate FLP and split it into shares.
+        prove_rand = self.prove_rand(prove_rand_seed)
+        proof = self.flp.prove(beta, prove_rand, joint_rand)
+        helper_proof_share = self.helper_proof_share(helper_seed)
+        leader_proof_share = vec_sub(proof, helper_proof_share)
 
-        public_share = (vidpf_public_share, flp_public_share)
+        public_share = (correction_words, joint_rand_parts)
         input_shares = [
-            (vidpf_keys[0], flp_leader_proof_share, flp_leader_seed),
-            (vidpf_keys[1], None, cast(Optional[bytes], flp_helper_seed)),
+            (keys[0], leader_proof_share, leader_seed),
+            (keys[1], None, cast(Optional[bytes], helper_seed)),
         ]
         return (public_share, input_shares)
 
@@ -183,23 +171,17 @@ class Mastic(
                  agg_param: MasticAggParam,
                  previous_agg_params: list[MasticAggParam],
                  ) -> bool:
-        (level, prefixes, do_range_check) = agg_param
-
         # Check that the range check is done exactly once.
-        first_level_range_check = \
-            (do_range_check and len(previous_agg_params) == 0) or \
-            (not do_range_check and
+        range_checked = \
+            (agg_param[2] and len(previous_agg_params) == 0) or \
+            (not agg_param[2] and
                 any(agg_param[2] for agg_param in previous_agg_params))
 
-        # Check that the level is always larger or equal to the previous level.
-        levels = list(map(
-            lambda agg_param: agg_param[0],
-            previous_agg_params,
-        )) + [level]
-        levels_non_decreasing = all(
-            x <= y for (x, y) in zip(levels, levels[1:]))
+        # Check that the level is strictly increasing.
+        level_increased = len(previous_agg_params) == 0 or \
+            agg_param[0] > previous_agg_params[-1][0]
 
-        return first_level_range_check and levels_non_decreasing
+        return range_checked and level_increased
 
     def prep_init(
             self,
@@ -211,47 +193,43 @@ class Mastic(
             input_share: MasticInputShare,
     ) -> tuple[MasticPrepState, MasticPrepShare]:
         (level, prefixes, do_range_check) = agg_param
-        (vidpf_key, flp_proof_share, flp_seed) = \
+        (key, proof_share, seed) = \
             self.expand_input_share(agg_id, input_share)
-        (vidpf_public_share, flp_public_share) = public_share
-        joint_rand_parts = flp_public_share
+        (correction_words, joint_rand_parts) = public_share
 
         # Evaluate the VIDPF.
-        (beta_share, out_share, vidpf_proof) = self.vidpf.eval(
+        (beta_share, out_share, eval_proof) = self.vidpf.eval(
             agg_id,
-            vidpf_public_share,
-            vidpf_key,
+            correction_words,
+            key,
             level,
             prefixes,
             nonce,
         )
 
-        # Compute the FLP verifier share, if applicable.
-        corrected_joint_rand_seed = None
-        flp_prep_share = None
+        # Query the FLP if applicable.
+        joint_rand_part = None
+        joint_rand_seed = None
+        verifier_share = None
         if do_range_check:
-            flp_query_rand = self.query_rand(verify_key, nonce, level)
-            joint_rand_part = None
+            query_rand = self.query_rand(verify_key, nonce, level)
             joint_rand = []
             if self.flp.JOINT_RAND_LEN > 0:
-                assert flp_seed is not None
+                assert seed is not None
                 assert joint_rand_parts is not None
                 joint_rand_part = self.joint_rand_part(
-                    agg_id, flp_seed, vidpf_key,
-                    vidpf_public_share, nonce)
+                    agg_id, seed, key, correction_words, nonce)
                 joint_rand_parts[agg_id] = joint_rand_part
-                corrected_joint_rand_seed = self.joint_rand_seed(
+                joint_rand_seed = self.joint_rand_seed(
                     joint_rand_parts)
-                joint_rand = self.joint_rand(corrected_joint_rand_seed)
-            flp_prep_share = (
-                self.flp.query(
-                    beta_share,
-                    flp_proof_share,
-                    flp_query_rand,
-                    joint_rand,
-                    2,
-                ),
-                joint_rand_part
+                joint_rand = self.joint_rand(
+                    self.joint_rand_seed(joint_rand_parts))
+            verifier_share = self.flp.query(
+                beta_share,
+                proof_share,
+                query_rand,
+                joint_rand,
+                2,
             )
 
         # Concatenate the output shares into one aggregatable output, applying
@@ -261,8 +239,8 @@ class Mastic(
             truncated_out_share += [val_share[0]] + \
                 self.flp.truncate(val_share[1:])
 
-        prep_state = (truncated_out_share, corrected_joint_rand_seed)
-        prep_share = (vidpf_proof, flp_prep_share)
+        prep_state = (truncated_out_share, joint_rand_seed)
+        prep_share = (eval_proof, verifier_share, joint_rand_part)
         return (prep_state, prep_share)
 
     def prep_shares_to_prep(
@@ -271,57 +249,56 @@ class Mastic(
             prep_shares: list[MasticPrepShare],
     ) -> MasticPrepMessage:
         (_level, _prefixes, do_range_check) = agg_param
+
         if len(prep_shares) != 2:
             raise ValueError('unexpected number of prep shares')
 
-        (vidpf_proof_0, flp_prep_share_0) = prep_shares[0]
-        (vidpf_proof_1, flp_prep_share_1) = prep_shares[1]
-        if do_range_check:
-            assert flp_prep_share_0 is not None
-            assert flp_prep_share_1 is not None
-            (flp_verifier_share_0, flp_jr_0) = flp_prep_share_0
-            (flp_verifier_share_1, flp_jr_1) = flp_prep_share_1
-            if self.flp.JOINT_RAND_LEN > 0:
-                assert flp_jr_0 is not None
-                assert flp_jr_1 is not None
-                joint_rand_parts = [flp_jr_0, flp_jr_1]
+        (eval_proof_0,
+         verifier_share_0,
+         joint_rand_part_0) = prep_shares[0]
+        (eval_proof_1,
+         verifier_share_1,
+         joint_rand_part_1) = prep_shares[1]
 
         # Verify the VIDPF output.
-        if vidpf_proof_0 != vidpf_proof_1:
+        if eval_proof_0 != eval_proof_1:
             raise Exception('VIDPF verification failed')
 
-        # Finish verifying the FLP, if applicable.
-        if do_range_check:
-            if flp_verifier_share_0 == None or flp_verifier_share_1 == None:
-                raise ValueError('prep share with missing FLP verifier share')
+        if not do_range_check:
+            return None
+        if verifier_share_0 is None or verifier_share_1 is None:
+            raise ValueError('expected FLP verifier shares')
 
-            flp_verifier = vec_add(flp_verifier_share_0, flp_verifier_share_1)
-            if not self.flp.decide(flp_verifier):
-                raise Exception('FLP verification failed')
+        # Verify the FLP.
+        verifier = vec_add(verifier_share_0, verifier_share_1)
+        if not self.flp.decide(verifier):
+            raise Exception('FLP verification failed')
 
-            joint_rand_seed = None
-            if self.flp.JOINT_RAND_LEN > 0:
-                joint_rand_seed = self.joint_rand_seed(joint_rand_parts)
-            return joint_rand_seed
+        if self.flp.JOINT_RAND_LEN == 0:
+            return None
+        if joint_rand_part_0 is None or joint_rand_part_1 is None:
+            raise ValueError('expected FLP joint randomness parts')
 
-        return None
+        # Confirm the FLP joint randomness was computed properly.
+        prep_msg = self.joint_rand_seed([
+            joint_rand_part_0,
+            joint_rand_part_1,
+        ])
+        return prep_msg
 
     def prep_next(self,
                   prep_state: MasticPrepState,
                   prep_msg: MasticPrepMessage,
                   ) -> list[F]:
-        (out_share, corrected_joint_rand_seed) = prep_state
-        if corrected_joint_rand_seed is not None:
+        (truncated_out_share, joint_rand_seed) = prep_state
+        if joint_rand_seed is not None:
             if prep_msg is None:
-                raise ValueError('unexpected prep message')
+                raise ValueError('expected FLP joint randomness confirmation')
 
-            joint_rand_seed = prep_msg
-            # If joint randomness was used, check that the value computed by the
-            # Aggregators matches the value indicated by the Client.
-            if joint_rand_seed != corrected_joint_rand_seed:
-                raise Exception("FLP joint randomness verification failed")
+            if prep_msg != joint_rand_seed:
+                raise Exception('FLP joint randomness confirmation failed')
 
-        return out_share
+        return truncated_out_share
 
     def aggregate(self,
                   agg_param: MasticAggParam,
@@ -344,11 +321,10 @@ class Mastic(
             agg = vec_add(agg, agg_share)
 
         agg_result = []
-        for chunk_start in range(0, len(agg), 1+self.flp.OUTPUT_LEN):
-            chunk = agg[chunk_start:chunk_start+1+self.flp.OUTPUT_LEN]
+        while len(agg) > 0:
+            (chunk, agg) = front(self.flp.OUTPUT_LEN + 1, agg)
             meas_count = chunk[0].as_unsigned()
-            encoded_result = chunk[1:]
-            agg_result.append(self.flp.decode(encoded_result, meas_count))
+            agg_result.append(self.flp.decode(chunk[1:], meas_count))
         return agg_result
 
     def expand_input_share(
@@ -357,18 +333,18 @@ class Mastic(
             input_share: MasticInputShare,
     ) -> tuple[bytes, list[F], Optional[bytes]]:
         if agg_id == 0:
-            (vidpf_init_seed, flp_proof_share, flp_seed) = input_share
-            assert flp_proof_share is not None
+            (key, proof_share, seed) = input_share
+            assert proof_share is not None
         else:
-            (vidpf_init_seed, _, flp_seed) = input_share
-            assert flp_seed is not None
-            flp_proof_share = self.helper_proof_share(flp_seed)
-        return (vidpf_init_seed, flp_proof_share, flp_seed)
+            (key, _leader_proof_share, seed) = input_share
+            assert seed is not None
+            proof_share = self.helper_proof_share(seed)
+        return (key, proof_share, seed)
 
-    def helper_proof_share(self, flp_seed: bytes) -> list[F]:
+    def helper_proof_share(self, seed: bytes) -> list[F]:
         return self.xof.expand_into_vec(
             self.field,
-            flp_seed,
+            seed,
             dst(USAGE_PROOF_SHARE),
             b'',
             self.flp.PROOF_LEN,
@@ -383,33 +359,32 @@ class Mastic(
             self.flp.PROVE_RAND_LEN,
         )
 
-    def joint_rand_part(self,
-                        agg_id: int,
-                        flp_seed: bytes,
-                        vidpf_key: bytes,
-                        vidpf_public_share: list[CorrectionWord],
-                        nonce: bytes,
-                        ) -> bytes:
+    def joint_rand_part(
+            self,
+            agg_id: int,
+            seed: bytes,
+            key: bytes,
+            correction_words: list[CorrectionWord],
+            nonce: bytes,
+    ) -> bytes:
+        pub = self.vidpf.encode_public_share(correction_words)
         return self.xof.derive_seed(
-            flp_seed,
+            seed,
             dst(USAGE_JOINT_RAND_PART),
-            byte(agg_id) + nonce + vidpf_key +
-            self.vidpf.encode_public_share(vidpf_public_share),
+            byte(agg_id) + nonce + key + pub,
         )
 
-    def joint_rand_seed(self, joint_rand_parts: list[bytes]) -> bytes:
-        """Derive the joint randomness seed from its parts."""
+    def joint_rand_seed(self, parts: list[bytes]) -> bytes:
         return self.xof.derive_seed(
             zeros(self.xof.SEED_SIZE),
             dst(USAGE_JOINT_RAND_SEED),
-            concat(joint_rand_parts),
+            concat(parts),
         )
 
-    def joint_rand(self, joint_rand_seed: bytes) -> list[F]:
-        """Derive the joint randomness from its seed."""
+    def joint_rand(self, seed: bytes) -> list[F]:
         return self.xof.expand_into_vec(
             self.field,
-            joint_rand_seed,
+            seed,
             dst(USAGE_JOINT_RAND),
             b'',
             self.flp.JOINT_RAND_LEN,


### PR DESCRIPTION
* Fix some awkwardness in the control flow that was revealed when we added type enforcement (296698483fc89c3bd140cbc8a833afecae9b94d8). The main goal was to reduce the number of type assertions we needed.

* Remove "flp_" and "vidpf_" prefixes from variable names wherever which primitive they're associated with is clear in context.

* Avoid nesting the term "public share". In other words, Mastic's public is composed of VIDPF correction words and FLP joint rand parts; make these components explicit. This avoids confusing variable aliases, like `flp_public_share = joint_rand_parts`.

* Make `is_valid()` stricter by preventing aggregating at the same level of the VIDPF tree more than once. We don't know if this is secure, and in any case, this behavior isn't covered by the current proof. Also, try and make the spec of `is_valid()` a little simpler.

* Align the FLP joint randomness confirmation with @hannahdaviscrypto's implementation. Namely, the prep share includes the aggregator's joint randomness part, and `prep_shares_to_prep()` combines them into the true joint randomness seed. Then `prep_next()` just confirms that the true joint randomness seed matches the one it computed during `prep_init()`.

* Add a unit test that exercises Mastic with joint randomness. We had been testing this, with the `Sum` circuit; but the `Sum` circuit no longer uses joint randomness in the latest version of the base draft.

* Improve `is_valid()` unit tests by replacing `assert`s with `self.assertTrue()`s.